### PR TITLE
Output chord as {Text} unless it has control keys ("{")

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The words entered using a chord can include the following special features:
 
 Note that chord detection works for suffixes and all chords will also be detected when they follow a chorded prefix even when the 'Restrict chords while typing' is enabled.
 
-- **Special keys**: Other keys can be entered using expressions in curly braces: {Left}, {Right}, {Up}, {Down} to move the cursor, or {Tab}, {Backspace} and {Enter} can all be used.
+- **Control keys**: Other keys can be entered using expressions in curly braces: {Left}, {Right}, {Up}, {Down} to move the cursor, or {Tab}, {Backspace} and {Enter} can all be used. When using these control keys (or the character "{"), the expanded text is interpreted using AutoHotkey's modifiers and special keys.
 - **Combinations**: You can combine these features for example to create a suffix that also deletes the last letter of the previous word. (In English, this can be useful to modify verbs where you need to drop the last -e. So to write the word "having" using chords, you can use a chord for "have" and then a chord for "ing" that would be expanded to `~{Backspace}ing` -- so it acts as a suffix which removes the last character.)
 
 ## Feedback

--- a/source/zipchord.ahk
+++ b/source/zipchord.ahk
@@ -6,7 +6,7 @@ SetWorkingDir %A_ScriptDir%
 ; ZipChord by Pavel Soukenik
 ; Licensed under GPL-3.0
 ; See https://github.com/psoukie/zipchord/
-global version = "1.8.1"
+global version = "1.8.2"
 
 ; ------------------
 ;; Global Variables
@@ -283,8 +283,7 @@ KeyUp:
         sorted := Arrange(chord)
         Sleep output_delay
         if (chords.HasKey(sorted)) {
-            exp := chords[sorted] ; store the expanded text
-            
+            exp := chords[sorted] ; store the expanded text       
             ; detect and adjust expansion for suffixes and prefixes
             if (SubStr(exp, 1, 1) == "~") {
                 exp := SubStr(exp, 2)
@@ -298,16 +297,20 @@ KeyUp:
             } else {
                 prefix := false
             }
-
             ; if we aren't restricted, we print a chord
             if (suffix || IsUnrestricted()) {
                 RemoveRawChord(sorted)
                 OpeningSpace(suffix)
-                ; expanded chord: 
-                if ( NeedsCapitalization() )
-                    SendInput % "{Text}"RegExReplace(exp, "(^.)", "$U1") ; Uses {Text} because otherwise, Unicode extended characters could not be upper-cased correctly
-                else
+                if (InStr(exp, "{")) {
+                    ; we send any expanded text that includes { as straight directives:
                     SendInput % exp
+                } else {
+                    ; and there rest as {Text} that's capitalized if needed:
+                    if ( NeedsCapitalization() )
+                        SendInput % "{Text}"RegExReplace(exp, "(^.)", "$U1")
+                    else
+                        SendInput % "{Text}"exp
+                }
                 last_output := OUT_CHORD
                 ; ending smart space
                 if (prefix) {


### PR DESCRIPTION
Outputs expanded chord as {Text} by default unless it contains AHK control characters ("{"). Fixes #27 and documents the quirk of how chords behave with {Backspace} etc.